### PR TITLE
[Fika] [cli] [debug] wrong uri in create PR request

### DIFF
--- a/src/domain/service/connnect.service.ts
+++ b/src/domain/service/connnect.service.ts
@@ -70,7 +70,7 @@ export class ConnectService implements IConnectService {
   async createPullRequest(gitRepoUrl: string, notionPageUrl: string, issueNumber: number, prNumber: number): Promise<string> {
     try {
       const response = await this.axiosInstance.post(
-        "/git/release",
+        "/git/pull-request",
         {
           gitRepoUrl: gitRepoUrl,
           notionPageUrl: notionPageUrl,


### PR DESCRIPTION
Notion 다큐먼트: https://www.notion.so/Fika-cli-debug-wrong-uri-in-create-PR-request-bc06689eaa064b129a6ea6434c7d60d6
 해결이슈: #225