### PR TITLE
[Fika][cli] “fika d” a branch named 'develop' already exists error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fika-cli",
-  "version": "0.4.8-beta",
+  "version": "0.4.9-beta",
   "description": "",
   "author": {
     "name": "Wonmo Jung",

--- a/src/domain/service/git_platform.service.ts
+++ b/src/domain/service/git_platform.service.ts
@@ -11,6 +11,7 @@ import { IGitPlatformService, IssueWithPR } from "../entity/i_git_platform.servi
 import { AddOnConfig } from "../value_object/add_on_config.vo";
 import { VersionTag } from "../value_object/version_tag.vo";
 import { IConfigService } from "./i_config.service";
+import { platform } from "os";
 
 @injectable()
 export class GitPlatformService implements IGitPlatformService {
@@ -121,9 +122,13 @@ export class GitPlatformService implements IGitPlatformService {
   }
 
   async checkoutToBranchWithoutReset(branchName: string): Promise<void> {
-    const { stdout: commitId, stderr: branchNameErr } = await this.execP(
-      `git checkout ${branchName} 2>/dev/null || git checkout -b ${branchName}`
-    );
+    let command: string;
+    if (process.platform === "win32") {
+      command = `git checkout "${branchName}"; if (-not $?) { git checkout -b ${branchName} }`;
+    } else {
+      command = `git checkout ${branchName} 2>/dev/null || git checkout -b ${branchName}`;
+    }
+    await this.execP(command);
   }
   async getLatestTag(): Promise<VersionTag> {
     try {


### PR DESCRIPTION
Notion 다큐먼트: https://www.notion.so/fikadev/Fika-cli-fika-d-a-branch-named-develop-already-exists-error-b82aa1c817414fd4a3802633c14bfb72
 해결이슈: #353