### PR TITLE
[fika-cli] add test jira client id & add offline_access to scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/63a7d4c7-5ece-4b26-abd2-ac5fa4087a37/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220907%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220907T045022Z&X-Amz-Expires=86400&X-Amz-Signature=fda14ff6cbaf6eea4fe0bf151e5c8ca91eab7100aa89b1024730f72d14702385&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.png%22&x-id=GetObject" alt="Image" width="400" style="display: block; margin: 0 auto" />
 
 # Fika: A high-level git extension that helps team-shared development workflow.
+
 ---
 
 ## Overview
@@ -18,6 +19,7 @@ The goal of this extension is to make it simple to configure and share team-base
 Also Fika provides integration with issue tracking tools (e.g. Notion, Jira) and with github.
 
 With Fika, no more manual creation of issue and pull request and manual linking with issue tracking tools.
+
 ---
 
 ## Get Started
@@ -25,7 +27,6 @@ With Fika, no more manual creation of issue and pull request and manual linking 
 ### `fika init`
 
 You can generates sharable git-workflow configuration file named `.fikarc` inside the repository by answering some questions.
-
 
 ### `fika start <issue-url>`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fika-cli",
-  "version": "0.4.15-beta",
+  "version": "0.4.16",
   "description": "",
   "author": {
     "name": "Wonmo Jung",

--- a/plug_in/workspace_platform/jira/index.ts
+++ b/plug_in/workspace_platform/jira/index.ts
@@ -1,8 +1,9 @@
 import { WorkspacePlatform } from "@/domain/entity/add_on/workspace_platform.entity";
 
 const jiraAuthorizeUri: string = "https://auth.atlassian.com/authorize";
-const fikaJraClientId: string = "4CtGOOySCpovViYXMVwRtPuPdlZtg9gA";
-const jiraSocpes: string[] = ["read:jira-work", "write:jira-work"];
+const fikaJiraClientId: string = "4CtGOOySCpovViYXMVwRtPuPdlZtg9gA";
+const testFikaJiraClientId: string = "MmjvsYfSW4xFEiZmr9UBPRdeX2TjenIC";
+const jiraSocpes: string[] = ["read:jira-work", "write:jira-work", "offline_access"];
 
 export class JiraWorkspace extends WorkspacePlatform {
   constructor() {
@@ -11,10 +12,16 @@ export class JiraWorkspace extends WorkspacePlatform {
   }
 
   getAuthenticationUri(domain: string): string {
+    let clientId: string;
+    if (domain === process.env.TEST_API_ADDRESS) {
+      clientId = testFikaJiraClientId;
+    } else {
+      clientId = fikaJiraClientId;
+    }
     const redirectUri = `${domain}/workspace/${this.workspaceType}/callback`;
     const scopeParams = jiraSocpes.join("+");
 
-    const params = `audience=api.atlassian.com&client_id=${fikaJraClientId}&scope=${scopeParams}&redirect_uri=${redirectUri}&state=\${YOUR_USER_BOUND_VALUE}&response_type=code&prompt=consent`;
+    const params = `audience=api.atlassian.com&client_id=${fikaJiraClientId}&scope=${scopeParams}&redirect_uri=${redirectUri}&state=\${YOUR_USER_BOUND_VALUE}&response_type=code&prompt=consent`;
     const targetUri = `${jiraAuthorizeUri}?${params}`;
     return targetUri;
   }


### PR DESCRIPTION
Notion 다큐먼트: https://www.notion.so/fikadev/fika-cli-add-test-jira-client-id-add-offline_access-to-scope-986a8aee0df14cce98c8248e4411496e
 해결이슈: #389