### PR TITLE
[fika-cli] not using jira test client id 

### DIFF
--- a/plug_in/workspace_platform/jira/index.ts
+++ b/plug_in/workspace_platform/jira/index.ts
@@ -21,7 +21,7 @@ export class JiraWorkspace extends WorkspacePlatform {
     const redirectUri = `${domain}/workspace/${this.workspaceType}/callback`;
     const scopeParams = jiraSocpes.join("+");
 
-    const params = `audience=api.atlassian.com&client_id=${fikaJiraClientId}&scope=${scopeParams}&redirect_uri=${redirectUri}&state=${hash}&response_type=code&prompt=consent`;
+    const params = `audience=api.atlassian.com&client_id=${clientId}&scope=${scopeParams}&redirect_uri=${redirectUri}&state=${hash}&response_type=code&prompt=consent`;
     const targetUri = `${jiraAuthorizeUri}?${params}`;
     return targetUri;
   }


### PR DESCRIPTION
Notion 다큐먼트: https://www.notion.so/fikadev/fika-cli-not-using-jira-test-client-id-94bd7c63675a4a5097f0fdced0ce98c5
 해결이슈: #394