### PR TITLE
[fika-cli] “fika init” create local branches after checking remote branch

### DIFF
--- a/src/actions/git/init-fixed-branch.action.ts
+++ b/src/actions/git/init-fixed-branch.action.ts
@@ -1,12 +1,15 @@
 import SERVICE_IDENTIFIER from "@/config/constants/identifiers";
 import container from "@/config/ioc_config";
 import { IGitPlatformService } from "@/domain/entity/i_git_platform.service";
-import { IPromptService } from "@/domain/service/i-prompt.service";
 
 export const initFixedBranch = async (branchName: string): Promise<void> => {
   const gitPlatformService = container.get<IGitPlatformService>(
     SERVICE_IDENTIFIER.GitPlatformService
   );
   await gitPlatformService.checkoutToBranchWithoutReset(branchName);
-  await gitPlatformService.pushBranchWithUpstream(branchName);
+  await gitPlatformService.fetchFromRemote();
+  const isRemoteBranchExist = await gitPlatformService.checkRemoteBranchExist(branchName);
+  if (!isRemoteBranchExist) {
+    await gitPlatformService.pushBranchWithUpstream(branchName);
+  }
 };

--- a/src/actions/git/init-fixed-branch.action.ts
+++ b/src/actions/git/init-fixed-branch.action.ts
@@ -1,0 +1,12 @@
+import SERVICE_IDENTIFIER from "@/config/constants/identifiers";
+import container from "@/config/ioc_config";
+import { IGitPlatformService } from "@/domain/entity/i_git_platform.service";
+import { IPromptService } from "@/domain/service/i-prompt.service";
+
+export const initFixedBranch = async (branchName: string): Promise<void> => {
+  const gitPlatformService = container.get<IGitPlatformService>(
+    SERVICE_IDENTIFIER.GitPlatformService
+  );
+  await gitPlatformService.checkoutToBranchWithoutReset(branchName);
+  await gitPlatformService.pushBranchWithUpstream(branchName);
+};

--- a/src/actions/git/init-git-repo.action.ts
+++ b/src/actions/git/init-git-repo.action.ts
@@ -1,0 +1,18 @@
+import SERVICE_IDENTIFIER from "@/config/constants/identifiers";
+import container from "@/config/ioc_config";
+import { IGitPlatformService } from "@/domain/entity/i_git_platform.service";
+import { IPromptService } from "@/domain/service/i-prompt.service";
+
+export const initGitRepo = async (): Promise<void> => {
+  const gitPlatformService = container.get<IGitPlatformService>(
+    SERVICE_IDENTIFIER.GitPlatformService
+  );
+  const promptService = container.get<IPromptService>(SERVICE_IDENTIFIER.PromptService);
+  if (!gitPlatformService.isGitRepo()) {
+    await gitPlatformService.gitInit();
+  }
+  if (!(await gitPlatformService.isThereRemoteUrl())) {
+    const remoteUrl = await promptService.askRemoteUrl();
+    await gitPlatformService.setRemoteUrl(remoteUrl);
+  }
+};

--- a/src/command/init/init.action.ts
+++ b/src/command/init/init.action.ts
@@ -1,3 +1,5 @@
+import { initFixedBranch } from "@/actions/git/init-fixed-branch.action";
+import { initGitRepo } from "@/actions/git/init-git-repo.action";
 import {
   defaultLocalConfig,
   developBranchCandidates,
@@ -35,12 +37,8 @@ export const initAction = async () => {
     "release",
     foundReleaseBrances
   );
-  await gitPlatformService.gitInit();
-  if (!(await gitPlatformService.isThereRemoteUrl())) {
-    const remoteUrl = await promptService.askRemoteUrl();
-    await gitPlatformService.setRemoteUrl(remoteUrl);
-  }
-  await gitPlatformService.checkoutToBranchWithoutReset(developBranchName);
+  await initGitRepo();
+  await gitPlatformService.checkoutToBranchWithoutReset(mainBranchName);
   const initialConfig = JSON.parse(JSON.stringify(defaultLocalConfig));
   initialConfig.branchNames = {
     develop: developBranchName,
@@ -50,8 +48,8 @@ export const initAction = async () => {
   };
   configService.createLocalConfig(initialConfig);
   await gitPlatformService.stageAllChanges();
-  await gitPlatformService.commitWithMessage("Initial commit");
-  await gitPlatformService.checkoutToBranchWithoutReset(mainBranchName);
-  await gitPlatformService.checkoutToBranchWithoutReset(releaseBranchName);
-  await gitPlatformService.checkoutToBranchWithoutReset(developBranchName);
+  await gitPlatformService.commitWithMessage("Add .fikarc for fika configuration");
+  await initFixedBranch(mainBranchName);
+  await initFixedBranch(releaseBranchName);
+  await initFixedBranch(developBranchName);
 };

--- a/src/domain/entity/i_git_platform.service.ts
+++ b/src/domain/entity/i_git_platform.service.ts
@@ -43,4 +43,5 @@ export interface IGitPlatformService {
   removeRemoteUrl(): Promise<void>;
   setRemoteUrl(remoteUrl: string): Promise<void>;
   isGitRepo(): boolean;
+  checkHeadExist(): Promise<boolean>;
 }

--- a/src/domain/entity/i_git_platform.service.ts
+++ b/src/domain/entity/i_git_platform.service.ts
@@ -46,4 +46,5 @@ export interface IGitPlatformService {
   checkHeadExist(): Promise<boolean>;
   getUpstreamBranch(branchName: string): Promise<string>;
   pushBranchWithUpstream(branchName: string): Promise<void>;
+  checkRemoteBranchExist(branchName: string): Promise<boolean>;
 }

--- a/src/domain/entity/i_git_platform.service.ts
+++ b/src/domain/entity/i_git_platform.service.ts
@@ -44,4 +44,5 @@ export interface IGitPlatformService {
   setRemoteUrl(remoteUrl: string): Promise<void>;
   isGitRepo(): boolean;
   checkHeadExist(): Promise<boolean>;
+  getUpstreamBranch(branchName: string): Promise<string>;
 }

--- a/src/domain/entity/i_git_platform.service.ts
+++ b/src/domain/entity/i_git_platform.service.ts
@@ -45,4 +45,5 @@ export interface IGitPlatformService {
   isGitRepo(): boolean;
   checkHeadExist(): Promise<boolean>;
   getUpstreamBranch(branchName: string): Promise<string>;
+  pushBranchWithUpstream(branchName: string): Promise<void>;
 }

--- a/src/domain/entity/i_git_platform.service.ts
+++ b/src/domain/entity/i_git_platform.service.ts
@@ -47,4 +47,5 @@ export interface IGitPlatformService {
   getUpstreamBranch(branchName: string): Promise<string>;
   pushBranchWithUpstream(branchName: string): Promise<void>;
   checkRemoteBranchExist(branchName: string): Promise<boolean>;
+  undoCommitAndModification(): Promise<void>;
 }

--- a/src/domain/service/git_platform.service.ts
+++ b/src/domain/service/git_platform.service.ts
@@ -29,6 +29,14 @@ export class GitPlatformService implements IGitPlatformService {
     this.configService = configService;
     this.gitRepoPath = gitRepoPath;
   }
+  async checkHeadExist(): Promise<boolean> {
+    const { stdout: statusOutput, stderr: diffError } = await this.execP("git status");
+    if (statusOutput.includes("No commits yet")) {
+      return false;
+    } else {
+      return true;
+    }
+  }
   isGitRepo(): boolean {
     return fs.existsSync(`${this.gitRepoPath}/.git`);
   }

--- a/src/domain/service/git_platform.service.ts
+++ b/src/domain/service/git_platform.service.ts
@@ -29,6 +29,20 @@ export class GitPlatformService implements IGitPlatformService {
     this.configService = configService;
     this.gitRepoPath = gitRepoPath;
   }
+  async getUpstreamBranch(branchName: string): Promise<string> {
+    try {
+      const { stdout: statusOutput, stderr } = await this.execP(
+        `git rev-parse --abbrev-ref ${branchName}@{upstream}`
+      );
+      return statusOutput.trim();
+    } catch (e) {
+      if (e.stdout.includes("fatal: no such branch")) {
+        return undefined;
+      } else {
+        throw new GitError("GitError", e);
+      }
+    }
+  }
   async checkHeadExist(): Promise<boolean> {
     const { stdout: statusOutput, stderr: diffError } = await this.execP("git status");
     if (statusOutput.includes("No commits yet")) {

--- a/src/domain/service/git_platform.service.ts
+++ b/src/domain/service/git_platform.service.ts
@@ -263,6 +263,12 @@ export class GitPlatformService implements IGitPlatformService {
     const { stdout: pushOut, stderr: pushErr } = await this.execP(`git push origin ${branchName}`);
   }
 
+  async pushBranchWithUpstream(branchName: string): Promise<void> {
+    const { stdout: pushOut, stderr: pushErr } = await this.execP(
+      `git push -u origin ${branchName}`
+    );
+  }
+
   async createIssue(issue: Issue): Promise<Issue> {
     if (this._gitPlatform) {
       return await this._gitPlatform.createIssue(issue);

--- a/src/domain/service/git_platform.service.ts
+++ b/src/domain/service/git_platform.service.ts
@@ -375,4 +375,8 @@ export class GitPlatformService implements IGitPlatformService {
   async setRemoteUrl(remoteUrl: string): Promise<void> {
     await this.execP(`git remote add origin ${remoteUrl}`);
   }
+
+  async undoCommitAndModification(): Promise<void> {
+    await this.execP(`git reset HEAD~ && git checkout -- .`);
+  }
 }

--- a/src/domain/service/git_platform.service.ts
+++ b/src/domain/service/git_platform.service.ts
@@ -94,6 +94,7 @@ export class GitPlatformService implements IGitPlatformService {
       }
     } catch (e) {
       const message = e.stdout + e.stderr;
+      console.log("🧪", " in GitPlatformService: ", "message: ", message);
       if (message.includes("Merge conflict")) {
         await this.abortMerge();
         throw new GitError("GitError:MergeConflict");

--- a/src/domain/service/git_platform.service.ts
+++ b/src/domain/service/git_platform.service.ts
@@ -29,6 +29,19 @@ export class GitPlatformService implements IGitPlatformService {
     this.configService = configService;
     this.gitRepoPath = gitRepoPath;
   }
+
+  async checkRemoteBranchExist(branchName: string): Promise<boolean> {
+    try {
+      await this.execP(`git show-branch remotes/origin/${branchName}`);
+      return true;
+    } catch (e) {
+      if (e.stdout.includes("fatal: bad sha1 reference")) {
+        return false;
+      } else {
+        throw new GitError("GitError", e);
+      }
+    }
+  }
   async getUpstreamBranch(branchName: string): Promise<string> {
     try {
       const { stdout: statusOutput, stderr } = await this.execP(

--- a/src/domain/service/git_platform.service.ts
+++ b/src/domain/service/git_platform.service.ts
@@ -35,7 +35,8 @@ export class GitPlatformService implements IGitPlatformService {
       await this.execP(`git show-branch remotes/origin/${branchName}`);
       return true;
     } catch (e) {
-      if (e.stdout.includes("fatal: bad sha1 reference")) {
+      const message = e.stdout + e.stderr;
+      if (message.includes("fatal: bad sha1 reference")) {
         return false;
       } else {
         throw new GitError("GitError", e);
@@ -49,7 +50,8 @@ export class GitPlatformService implements IGitPlatformService {
       );
       return statusOutput.trim();
     } catch (e) {
-      if (e.stdout.includes("fatal: no such branch")) {
+      const message = e.stdout + e.stderr;
+      if (message.includes("fatal: no such branch")) {
         return undefined;
       } else {
         throw new GitError("GitError", e);
@@ -91,7 +93,8 @@ export class GitPlatformService implements IGitPlatformService {
         return "UPDATED";
       }
     } catch (e) {
-      if (e.stdout.includes("Merge conflict")) {
+      const message = e.stdout + e.stderr;
+      if (message.includes("Merge conflict")) {
         await this.abortMerge();
         throw new GitError("GitError:MergeConflict");
       } else if (e.stdout.includes("conflict")) {
@@ -159,7 +162,8 @@ export class GitPlatformService implements IGitPlatformService {
         `git commit -m "${message}"`
       );
     } catch (e) {
-      if (e.stdout.includes("nothing to commit")) {
+      const message = e.stdout + e.stderr;
+      if (message.includes("nothing to commit")) {
         throw new NothingToCommit("NothingToCommit");
       } else {
         throw e;
@@ -201,8 +205,9 @@ export class GitPlatformService implements IGitPlatformService {
       }
       await this.execP(command);
     } catch (e) {
+      const message = e.stdout + e.stderr;
       if (
-        e.stdout.includes(`is not a commit and a branch ${branchName} cannot be created from it`)
+        message.includes(`is not a commit and a branch ${branchName} cannot be created from it`)
       ) {
         throw new NoRemoteBranch("NoRemoteBranch");
       } else {

--- a/test/command/checkout-developp-branch/checkout-develop-branch.action.test.ts
+++ b/test/command/checkout-developp-branch/checkout-develop-branch.action.test.ts
@@ -7,9 +7,8 @@ import { IPromptService } from "@/domain/service/i-prompt.service";
 import { IConfigService } from "@/domain/service/i_config.service";
 import { IMessageService } from "@/domain/service/i_message.service";
 import { Uuid } from "@/domain/value_object/uuid.vo";
-import exp from "constants";
 import { TEST_CPR_BRANCH_NAME } from "test/test-constants";
-import { checkAndCloneRepo, createTestConfig, deleteBranch, restoreGitRepo, setUseToken } from "test/test-utils";
+import { checkAndCloneRepo, createTestConfig, restoreGitRepo, setUseToken } from "test/test-utils";
 
 const gitPlatformService = container.get<IGitPlatformService>(SERVICE_IDENTIFIER.GitPlatformService);
 const messageService = container.get<IMessageService>(SERVICE_IDENTIFIER.MessageService);
@@ -26,6 +25,7 @@ beforeEach(async()=>{
   jest.restoreAllMocks();
   jest.spyOn(process.stdout, "write").mockImplementation(()=>true);
   jest.spyOn(console, "log").mockImplementation(()=>true);
+  jest.spyOn(promptService, "confirmAction").mockImplementation(()=>Promise.resolve(true));
   jest.spyOn(messageService, 'showSuccess').mockImplementation(()=>{});
   jest.spyOn(configService, 'getWorkspaceId').mockImplementation(()=>new Uuid('d3224eba-6e67-4730-9b6f-a9ef1dc7e4ac'));
   await gitPlatformService.checkoutToBranchWithoutReset('develop');
@@ -42,6 +42,7 @@ afterAll(() => {
 });
 
 it("1.test checkout-develop-branch if develop was set", async () => {
+  
     const localConfig = defaultLocalConfig;
   localConfig.branchNames.develop = "develop";
   await gitPlatformService.checkoutToBranchWithoutReset(TEST_CPR_BRANCH_NAME);

--- a/test/command/finish/finish.action.test.ts
+++ b/test/command/finish/finish.action.test.ts
@@ -55,9 +55,6 @@ afterAll(() => {
 it("1.test git merge conflict", async ()=>{
   jest.spyOn(promptService, 'confirmAction').mockImplementation((message: string) => Promise.resolve(true));
   await gitPlatformService.checkoutToBranchWithoutReset("conflicting");
-  await gitPlatformService.stageAllChanges();
-  await gitPlatformService.pullFrom("conflicting");
-  
   let message: string = 'not yet'
   try{
     await pullAndCheckConflict("conflicting_2");

--- a/test/command/finish/finish.action.test.ts
+++ b/test/command/finish/finish.action.test.ts
@@ -32,6 +32,13 @@ beforeEach(async()=>{
   jest.spyOn(console, "log").mockImplementation(()=>true);
   jest.spyOn(messageService, 'showSuccess').mockImplementation(()=>{});
   jest.spyOn(configService, 'getWorkspaceId').mockImplementation(()=>new Uuid('d3224eba-6e67-4730-9b6f-a9ef1dc7e4ac'));
+  jest.spyOn(gitPlatformService, 'createPR').mockImplementation((issue)=>{
+    const updated = {
+      ...issue,
+      gitPrUrl: 'https://github.com/fika-dev/fika-cli-test-samples/pull/1502'
+    }
+    return Promise.resolve(updated);
+  });
   await gitPlatformService.checkoutToBranchWithoutReset('develop');
   await restoreGitRepo(process.env.TESTING_REPO_PATH);
 });

--- a/test/command/info/info.action.test.ts
+++ b/test/command/info/info.action.test.ts
@@ -1,19 +1,14 @@
-import { createPR } from "@/actions/complex/create-PR.action";
 import { infoAction } from "@/command/info/info.action";
-import { defaultLocalConfig } from "@/config/constants/default_config";
 import SERVICE_IDENTIFIER from "@/config/constants/identifiers";
 import container from "@/config/ioc_config";
 import { Issue } from "@/domain/entity/issue.entity";
 import { IGitPlatformService } from "@/domain/entity/i_git_platform.service";
 import { ConnectService } from "@/domain/service/connnect.service";
-import { IPromptService } from "@/domain/service/i-prompt.service";
 import { IConfigService } from "@/domain/service/i_config.service";
 import { IMessageService } from "@/domain/service/i_message.service";
-import { GhPrAlreadyExists } from "@/domain/value_object/exceptions/gh_pr_already_exists";
 import { Uuid } from "@/domain/value_object/uuid.vo";
-import exp from "constants";
 import { TEST_CPR_BRANCH_NAME } from "test/test-constants";
-import { checkAndCloneRepo, createTestConfig, deleteBranch, restoreGitRepo, setUseToken } from "test/test-utils";
+import { checkAndCloneRepo, createTestConfig, restoreGitRepo, setUseToken } from "test/test-utils";
 
 const gitPlatformService = container.get<IGitPlatformService>(SERVICE_IDENTIFIER.GitPlatformService);
 const messageService = container.get<IMessageService>(SERVICE_IDENTIFIER.MessageService);
@@ -21,6 +16,7 @@ const configService = container.get<IConfigService>(SERVICE_IDENTIFIER.ConfigSer
 const connectService = container.get<ConnectService>(SERVICE_IDENTIFIER.ConnectService);
 
 beforeAll(async () => {
+  jest.restoreAllMocks();
   await checkAndCloneRepo();
   createTestConfig(process.env.TESTING_PATH + "/.fika");
   setUseToken(process.env.TESTING_USER_TOKEN);
@@ -72,32 +68,32 @@ it("1.test info on a issue branch", async () => {
 });
 
 it("2.test info message for the develop branch", async () => {
-    jest.spyOn(gitPlatformService, 'getGitRepoUrl').mockImplementation(async () => 'https://github.com/tuxshido/repo');
-    jest.spyOn(gitPlatformService, 'getBranchName').mockImplementation(async () => 'develop');
+    jest.spyOn(gitPlatformService, 'getGitRepoUrl').mockImplementation(async () => Promise.resolve('https://github.com/tuxshido/repo'));
+    jest.spyOn(gitPlatformService, 'getBranchName').mockImplementation(async () => Promise.resolve('develop'));
     const spy = jest.spyOn(messageService, 'showSuccess').mockImplementation(() => { });
     await infoAction();
     expect(spy).toBeCalledWith('You are on the develop branch, you can start a new branch with "fika start <issue url>"', undefined);
 });
 
 it("3.test info message for the release branch", async () => {
-    jest.spyOn(gitPlatformService, 'getGitRepoUrl').mockImplementation(async () => 'https://github.com/tuxshido/repo');
-    jest.spyOn(gitPlatformService, 'getBranchName').mockImplementation(async () => 'release');
+    jest.spyOn(gitPlatformService, 'getGitRepoUrl').mockImplementation(async () => Promise.resolve('https://github.com/tuxshido/repo'));
+    jest.spyOn(gitPlatformService, 'getBranchName').mockImplementation(async () => Promise.resolve('release'));
     const spy = jest.spyOn(messageService, 'showSuccess').mockImplementation(() => { });
     await infoAction();
     expect(spy).toBeCalledWith('You are on the release branch, you can start a new branch with "fika start <issue url>"', undefined);
 });
 
 it("4.test info message for the main branch", async () => {
-    jest.spyOn(gitPlatformService, 'getGitRepoUrl').mockImplementation(async () => 'https://github.com/tuxshido/repo');
-    jest.spyOn(gitPlatformService, 'getBranchName').mockImplementation(async () => 'master');
+    jest.spyOn(gitPlatformService, 'getGitRepoUrl').mockImplementation(async () => Promise.resolve('https://github.com/tuxshido/repo'));
+    jest.spyOn(gitPlatformService, 'getBranchName').mockImplementation(async () => Promise.resolve('master'));
     const spy = jest.spyOn(messageService, 'showSuccess').mockImplementation(() => { });
     await infoAction();
     expect(spy).toBeCalledWith('You are on the main branch, you can start a new branch with "fika start <issue url>"', undefined);
 });
 
 it("5.test info message for a non-valid", async () => {
-    jest.spyOn(gitPlatformService, 'getGitRepoUrl').mockImplementation(async () => 'https://github.com/tuxshido/repo');
-    jest.spyOn(gitPlatformService, 'getBranchName').mockImplementation(async () => 'nan');
+    jest.spyOn(gitPlatformService, 'getGitRepoUrl').mockImplementation(async () => Promise.resolve('https://github.com/tuxshido/repo'));
+    jest.spyOn(gitPlatformService, 'getBranchName').mockImplementation(async () => Promise.resolve('nan'));
     jest.spyOn(connectService, 'getIssueRecord').mockImplementation(async () => {
         return null as Issue} );
     const spy = jest.spyOn(messageService, 'showSuccess').mockImplementation(() => { });

--- a/test/command/init/init.action.test.ts
+++ b/test/command/init/init.action.test.ts
@@ -89,6 +89,8 @@ test('2. get main, develop and release branch after initialiase', async () => {
   expect(branchArr).toContain('test_master');
   const currentBranch = await gitPlatformService.getBranchName();
   expect(currentBranch).toEqual('test_develop');
+  commitSpy.mockRestore();
+  pushSpy.mockRestore();
 });
 
 test('3. test prompt askBranchName', async () => { 

--- a/test/command/pull/pull.action.test.ts
+++ b/test/command/pull/pull.action.test.ts
@@ -4,7 +4,9 @@ import container from "@/config/ioc_config";
 import { clearLocalConfig, clearTestFikaPath, readLocalConfig, sendPromptData } from "test/test-utils";
 import { IGitPlatformService } from "@/domain/entity/i_git_platform.service";
 import { IMessageService } from "@/domain/service/i_message.service";
+import { IPromptService } from "@/domain/service/i-prompt.service";
 const gitPlatformService = container.get<IGitPlatformService>(SERVICE_IDENTIFIER.GitPlatformService);
+const promptService = container.get<IPromptService>(SERVICE_IDENTIFIER.PromptService);
 
 afterEach(()=>{
   jest.clearAllMocks();
@@ -16,6 +18,7 @@ beforeEach(()=>{
 });
 
 beforeAll(() => {
+  jest.spyOn(promptService, 'confirmAction').mockImplementation((message: string) => Promise.resolve(true));
   clearTestFikaPath(process.env.TESTING_PATH);
   clearLocalConfig(process.env.TESTING_REPO_PATH);
 });

--- a/test/command/start/start.action.test.ts
+++ b/test/command/start/start.action.test.ts
@@ -27,6 +27,13 @@ beforeEach(async()=>{
   jest.spyOn(messageService, 'showSuccess').mockImplementation(()=>{});
   jest.spyOn(configService, 'getWorkspaceId').mockImplementation(()=>new Uuid('d3224eba-6e67-4730-9b6f-a9ef1dc7e4ac'));
   jest.spyOn(configService, 'getWorkspaceType').mockImplementation(()=>'notion');
+  jest.spyOn(gitPlatformService, 'createIssue').mockImplementation((issue)=>{
+    const updated = {
+      ...issue,
+      gitIssueUrl: 'https://github.com/fika-dev/fika-cli-test-samples/issues/1507'
+    }
+    return Promise.resolve(updated);
+  });
   await gitPlatformService.checkoutToBranchWithoutReset('develop');
   await restoreGitRepo(process.env.TESTING_REPO_PATH);
 });
@@ -72,7 +79,7 @@ test('2.1. catch user stopped exception', async () => {
   expect(message).toEqual("UserStopped:UnstagedChange");
 });
 
-test('3. test start action without existing issue', async () => {
+test('3. notion test start action without existing issue', async () => {
   await checkAndDeleteIssue(TEST_START_DOC_ID);
   const spy = jest.spyOn(messageService, 'showSuccess').mockImplementation(()=>{});
   await gitPlatformService.checkoutToBranchWithReset('develop');

--- a/test/command/start/start.action.test.ts
+++ b/test/command/start/start.action.test.ts
@@ -65,6 +65,9 @@ test('2. check unstaged change', async () => {
 test('2.1. catch user stopped exception', async () => {
   await checkAndDeleteIssue(TEST_START_DOC_ID);
   await gitPlatformService.checkoutToBranchWithReset("develop");
+  const localConfig = JSON.parse(JSON.stringify(defaultLocalConfig));
+  localConfig.start.pullBeforeAlways = false;
+  jest.spyOn(configService, 'getLocalConfig').mockImplementation(() => localConfig);
   makeMeaninglessChange(TEST_CHANGE_FILE_PATH);
   const spy = jest.spyOn(promptService, "confirmAction").mockImplementationOnce((m)=>{
     return Promise.resolve(false)

--- a/test/command/start/start.action.test.ts
+++ b/test/command/start/start.action.test.ts
@@ -64,6 +64,7 @@ test('2. check unstaged change', async () => {
 
 test('2.1. catch user stopped exception', async () => {
   await checkAndDeleteIssue(TEST_START_DOC_ID);
+  await gitPlatformService.checkoutToBranchWithReset("develop");
   makeMeaninglessChange(TEST_CHANGE_FILE_PATH);
   const spy = jest.spyOn(promptService, "confirmAction").mockImplementationOnce((m)=>{
     return Promise.resolve(false)

--- a/test/command/start/start.action.test.ts
+++ b/test/command/start/start.action.test.ts
@@ -59,7 +59,6 @@ test('2.1. catch user stopped exception', async () => {
   await checkAndDeleteIssue(TEST_START_DOC_ID);
   makeMeaninglessChange(TEST_CHANGE_FILE_PATH);
   const spy = jest.spyOn(promptService, "confirmAction").mockImplementationOnce((m)=>{
-    console.log('🧪', ' in StartActionTest: ', 'm: ',m);
     return Promise.resolve(false)
   });
   let message: string

--- a/test/command/start/start.action.test.ts
+++ b/test/command/start/start.action.test.ts
@@ -35,10 +35,10 @@ afterEach(() => {
   messageService.endWaiting();
 });
 
-test('1. test pull from develop', async () => {
-  await gitPlatformService.checkoutToBranchWithoutReset('develop');
-  await gitPlatformService.pullFrom('develop');
-});
+// test('1. test pull from develop', async () => {
+//   await gitPlatformService.checkoutToBranchWithoutReset('develop');
+//   await gitPlatformService.pullFrom('develop');
+// });
 
 test('2. check unstaged change', async () => {
   await gitPlatformService.checkoutToBranchWithReset(TEST_CPR_BRANCH_NAME);


### PR DESCRIPTION
Notion 다큐먼트: https://www.notion.so/fikadev/fika-cli-fika-init-create-local-branches-after-checking-remote-branch-8a7eeec3834f4b17abbc947f59918147
 해결이슈: #408